### PR TITLE
Fix recursion error on calling `method`.

### DIFF
--- a/requests_openapi/core.py
+++ b/requests_openapi/core.py
@@ -81,7 +81,7 @@ class Operation(object):
 
     @property
     def method(self):
-        return self.method
+        return self._method
 
     @property
     def path(self):


### PR DESCRIPTION
Looks like it's missing a `_`.

On calling `client.tag.method`, it should return `self._method`, but is instead calling `self.method`, resulting an infinite recursion.